### PR TITLE
Allow exclude and exclude_daemons in markers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,6 @@ regex to match excluded thread names:
 If you want to ignore leaked daemon threads, specify
 `threadleak_exclude_daemons` (defaults to `False`):
 
-
 .. code-block:: ini
 
     [pytest]

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,26 @@ If you want to ignore leaked daemon threads, specify
     threadleak = True
     threadleak_exclude_daemons = True
 
+The `exclude` and `exclude_daemons` options can also be used in module marker,
+class marker or function markers, to enable the option only for certain moudle,
+test class, or test function:
+
+.. code-block:: python
+
+    @pytest.mark.threadleak(exclude=r"pool/\d+")
+    def test_exclude_leaked_threads_by_regrex():
+        ...
+
+    @pytest.mark.threadleak(exclude_daemons=True)
+    def test_exclude_leaked_daemon_threads():
+        ...
+
+    def test_no_leaked_threads_here():
+        ...
+
+In this example, thread "pool/42" is allowed to leak in the first test, and all
+daemon threads are allowed to leak in the second test. No threads area allowed
+to leak in the last test.
 
 Contributing
 ------------

--- a/pytest_threadleak.py
+++ b/pytest_threadleak.py
@@ -39,13 +39,13 @@ def pytest_configure(config):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    start_threads = None
-    exclude_regex = item.config.getini("threadleak_exclude")
-    exclude_daemons = item.config.getini("threadleak_exclude_daemons")
-    if is_enabled(item):
+    enabled = is_enabled(item)
+    if enabled:
+        exclude_regex = item.config.getini("threadleak_exclude")
+        exclude_daemons = item.config.getini("threadleak_exclude_daemons")
         start_threads = current_threads(exclude_regex, exclude_daemons)
     yield
-    if start_threads:
+    if enabled:
         end_threads = current_threads(exclude_regex, exclude_daemons)
         leaked_threads = end_threads - start_threads
         if leaked_threads:

--- a/test_threadleak.py
+++ b/test_threadleak.py
@@ -189,7 +189,7 @@ def test_leak_enabled_exclude_all(testdir):
     assert result.ret == 0
 
 
-def test_leak_enabled_exclude_daemons_when_leaked_are_daemon(testdir):
+def test_leak_enabled_exclude_daemons(testdir):
     testdir.makeini(INI_ENABLED_WITH_EXCLUDE_DAEMONS)
     testdir.makepyfile(make_source(daemon=True))
     result = testdir.runpytest("-v")
@@ -197,7 +197,7 @@ def test_leak_enabled_exclude_daemons_when_leaked_are_daemon(testdir):
     assert result.ret == 0
 
 
-def test_leak_enabled_exclude_daemons_when_leaked_are_not_daemon(testdir):
+def test_leak_enabled_include_non_daemons(testdir):
     testdir.makeini(INI_ENABLED_WITH_EXCLUDE_DAEMONS)
     testdir.makepyfile(make_source(daemon=False))
     result = testdir.runpytest("-v")

--- a/test_threadleak.py
+++ b/test_threadleak.py
@@ -189,6 +189,39 @@ def test_leak_enabled_exclude_all(testdir):
     assert result.ret == 0
 
 
+def test_leak_enabled_exclude_module_marker(testdir):
+    testdir.makepyfile(
+        make_source(
+            module_marker="pytestmark = pytest.mark.threadleak(exclude='leaked-thread-')",
+        ),
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_leak PASSED*"])
+    assert result.ret == 0
+
+
+def test_leak_enabled_exclude_class_marker(testdir):
+    testdir.makepyfile(
+        make_source(
+            class_marker="@pytest.mark.threadleak(exclude='leaked-thread-')",
+        ),
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_leak PASSED*"])
+    assert result.ret == 0
+
+
+def test_leak_enabled_exclude_function_marker(testdir):
+    testdir.makepyfile(
+        make_source(
+            function_marker="@pytest.mark.threadleak(exclude='leaked-thread-')",
+        ),
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_leak PASSED*"])
+    assert result.ret == 0
+
+
 def test_leak_enabled_exclude_daemons(testdir):
     testdir.makeini(INI_ENABLED_WITH_EXCLUDE_DAEMONS)
     testdir.makepyfile(make_source(daemon=True))
@@ -203,6 +236,42 @@ def test_leak_enabled_include_non_daemons(testdir):
     result = testdir.runpytest("-v")
     result.stdout.fnmatch_lines(["*::test_leak FAILED*"])
     assert result.ret == 1
+
+
+def test_leak_enabled_exclude_daemons_module_marker(testdir):
+    testdir.makepyfile(
+        make_source(
+            module_marker="pytestmark = pytest.mark.threadleak(exclude_daemons=True)",
+            daemon=True,
+        ),
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_leak PASSED*"])
+    assert result.ret == 0
+
+
+def test_leak_enabled_exclude_daemons_class_marker(testdir):
+    testdir.makepyfile(
+        make_source(
+            class_marker="@pytest.mark.threadleak(exclude_daemons=True)",
+            daemon=True,
+        ),
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_leak PASSED*"])
+    assert result.ret == 0
+
+
+def test_leak_enabled_exclude_daemons_function_marker(testdir):
+    testdir.makepyfile(
+        make_source(
+            function_marker="@pytest.mark.threadleak(exclude_daemons=True)",
+            daemon=True,
+        ),
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_leak PASSED*"])
+    assert result.ret == 0
 
 
 def test_unexpected_marker_args(testdir):


### PR DESCRIPTION
These options could be used only as ini options. Now you can enable the
features also as module, class, or function markers. This is makes it
possible to keep your test suite clean of leaked threads but allow
leaked threads only in specific module, test class, or test function.
    
Allowing leaked threads in some cases is tricky since the leaked thread
can break unrelated tests when it terminates, but it may help in some
cases.
